### PR TITLE
Sketching out an implementation of a `RouteNotDiamond` node.

### DIFF
--- a/nd_example.py
+++ b/nd_example.py
@@ -1,3 +1,13 @@
+"""
+Run this example to see the sketch for a RouteNotDiamond node.
+
+```bash
+pyenv virtualenv 3.11 substrate-nd-example
+pyenv activate substrate-nd-example
+pip install substrate
+python nd_example.py
+```
+"""
 import os
 
 from dotenv import load_dotenv
@@ -68,7 +78,9 @@ def route_quickstart():
     print(f"story={story.id}, summarize_4o={summarize_4o.id}, summarize_sonnet={summarize_sonnet.id}, summary={summary.id}")
 
     # print(substrate.visualize(summary))
-    response = substrate.run(summary)
+    # response = substrate.run(summary)
+    # print(response)
+    response = substrate.run(route)
     print(response)
 
 if __name__ == "__main__":

--- a/nd_example.py
+++ b/nd_example.py
@@ -1,0 +1,75 @@
+import os
+
+from dotenv import load_dotenv
+
+from substrate import Substrate, ComputeText, sb, Secrets, If
+from substrate.run_notdiamond import RouteNotDiamond
+
+load_dotenv()
+
+SUBSTRATE_API_KEY = os.getenv("SUBSTRATE_API_KEY")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY")
+
+
+def quickstart():
+    substrate = Substrate(
+        api_key=SUBSTRATE_API_KEY,
+        secrets=Secrets(
+            openai=OPENAI_API_KEY,
+            anthropic=ANTHROPIC_API_KEY,
+        ),
+    )
+
+    story = ComputeText(
+        prompt="Write a short story about a raccoon eating a banana.",
+    )
+    summary = ComputeText(
+        prompt=sb.format("summarize: {story}", story=story.future.text)
+    )
+    response = substrate.run(summary)
+    summary_out = response.get(summary)
+    print(response)
+    print(summary_out)
+
+
+def route_quickstart():
+    substrate = Substrate(
+        api_key=SUBSTRATE_API_KEY,
+    )
+
+    story = ComputeText(
+        prompt="Write a short story about a raccoon eating a banana.",
+    )
+    route = RouteNotDiamond(
+        route_input=story,
+        models=["gpt-4o", "claude-3-5-sonnet-20240620"],
+    )
+    summarize_4o = ComputeText(
+        prompt=sb.concat(
+            "summarize: ",
+            story.future.text,
+        ),
+        model="gpt-4o",
+    )
+    summarize_sonnet = ComputeText(
+        prompt=sb.concat(
+            "summarize: ",
+            story.future.text,
+        ),
+        model="claude-3-5-sonnet-20240620",
+    )
+    summary = If(
+        condition=sb.jq(route.future.text, "output == 'gpt-4o'"),
+        value_if_true=summarize_4o.future.text,
+        value_if_false=summarize_sonnet.future.text,
+    )
+
+    print(f"story={story.id}, summarize_4o={summarize_4o.id}, summarize_sonnet={summarize_sonnet.id}, summary={summary.id}")
+
+    # print(substrate.visualize(summary))
+    response = substrate.run(summary)
+    print(response)
+
+if __name__ == "__main__":
+    route_quickstart()

--- a/substrate/run_notdiamond.py
+++ b/substrate/run_notdiamond.py
@@ -1,0 +1,56 @@
+import os
+from typing import List
+from typing_extensions import Literal
+
+from .nodes import ComputeText
+from .run_python import RunPython
+
+ComputeModels = Literal[
+    "Mistral7BInstruct",
+    "Mixtral8x7BInstruct",
+    "Llama3Instruct8B",
+    "Llama3Instruct70B",
+    "Llama3Instruct405B",
+    "Firellava13B",
+    "gpt-4o",
+    "gpt-4o-mini",
+    "claude-3-5-sonnet-20240620",
+]
+
+
+class RouteNotDiamond(RunPython):
+    def __init__(self, route_input: ComputeText, models: List[ComputeModels], *args, **kwargs):
+        super().__init__(
+            function=model_select,
+            kwargs={
+                'query': route_input.future.text,
+                "api_key": os.getenv("NOTDIAMOND_API_KEY"),
+                "models": models
+            },
+            pip_install=['notdiamond'],
+            *args, **kwargs
+        )
+
+
+def model_select(query: str, api_key: str, models: List[ComputeModels]) -> ComputeModels:
+    from notdiamond import NotDiamond
+
+    _compute_model_to_llm_config = {
+        "gpt-4o": "openai/gpt-4o",
+        "gpt-4o-mini": "openai/gpt-4o-mini",
+        "claude-3-5-sonnet-20240620": "anthropic/claude-3-5-sonnet-20240620",
+    }
+    _llm_config_str_to_compute_model = {
+        v: k for k, v in _compute_model_to_llm_config.items()
+    }
+
+    llm_configs = [
+        _compute_model_to_llm_config[model] for model in models
+    ]
+
+    notdiamond = NotDiamond(api_key=api_key or os.getenv("NOTDIAMOND_API_KEY"))
+    session_id, provider = notdiamond.model_select(
+        messages=[{"role": "user", "content": query}], model=llm_configs
+    )
+    print(f"Routing prompt for {session_id} to {provider}")
+    return _llm_config_str_to_compute_model[str(provider)]


### PR DESCRIPTION
An incredibly rough sketch (read: nonfunctioning) sketch of how Not Diamond might integrate with Substrate.

High-level:
- Introducing a `RouteNotDiamond` node which would route a `ComputeText` to one of the specified models.
- A subsequent `If` node can then invoke a `ComputeText` on the target model.

For some reason I can't quite check the output of a `RunNotDiamond` (itself just a `RunPython`) against a literal str in my `If` node, so the fully-routed graph is commented out. But we can execute the ND API call server-side, and clearly see a response for the given `ComputeText`. 🙌🏼 